### PR TITLE
Remove spairs, snext, and sipairs

### DIFF
--- a/luarules/gadgets/unit_morph.lua
+++ b/luarules/gadgets/unit_morph.lua
@@ -1347,8 +1347,6 @@ end
 local gameFrame;
 local SYNCED = SYNCED
 local CallAsTeam = CallAsTeam
-local spairs = spairs
-local snext = snext
 
 local spGetUnitPosition = Spring.GetUnitPosition
 
@@ -1489,7 +1487,7 @@ function gadget:Update()
   if (frame>oldFrame) then
     oldFrame = frame
     local morphUnitsSynced = SYNCED.morphUnits
-    if snext(morphUnitsSynced) then
+    if next(morphUnitsSynced) then
       local useLuaUI_ = Script.LuaUI('MorphUpdate')
       if (useLuaUI_~=useLuaUI) then --//Update Callins on change
         drawProgress = not Script.LuaUI('MorphDrawProgress')
@@ -1503,7 +1501,7 @@ function gadget:Update()
           then readTeam = Script.ALL_ACCESS_TEAM
           else readTeam = GetLocalTeamID() end
         CallAsTeam({ ['read'] = readTeam }, function()
-          for unitID, morphData in spairs(morphUnitsSynced) do
+          for unitID, morphData in pairs(morphUnitsSynced) do
             if (unitID and morphData)and(IsUnitVisible(unitID)) then
               morphTable[unitID] = {progress=morphData.progress, into=morphData.def.into, combatMorph = morphData.combatMorph}
             end
@@ -1619,7 +1617,7 @@ end
 function gadget:DrawWorld()
   local morphUnits = SYNCED.morphUnits
 
-  if (not snext(morphUnits)) then
+  if (not next(morphUnits)) then
     return --//no morphs to draw
   end
 
@@ -1637,7 +1635,7 @@ function gadget:DrawWorld()
   end
 
   CallAsTeam({ ['read'] = readTeam }, function()
-    for unitID, morphData in spairs(morphUnits) do
+    for unitID, morphData in pairs(morphUnits) do
       if (unitID and morphData)and(IsUnitVisible(unitID)) then
 		if morphData.combatMorph then
 		  DrawCombatMorphUnit(unitID, morphData,readTeam)	

--- a/luarules/system.lua
+++ b/luarules/system.lua
@@ -50,9 +50,9 @@ if (System == nil) then
         --  Unsynced Utilities
         --
         SYNCED = SYNCED,
-        snext = snext,
-        spairs = spairs,
-        sipairs = sipairs,
+        snext = next, -- the following 3 are deprecated, but defined in case any legacy code uses them
+        spairs = pairs,
+        sipairs = ipairs,
 
         --
         --  Standard libraries

--- a/luarules/utilities/tablefunctions.lua
+++ b/luarules/utilities/tablefunctions.lua
@@ -72,7 +72,7 @@ local function MakeRealTable(proxy, debugTag)
 	end
 	local proxyLocal = proxy
 	local ret = {}
-	for i,v in spairs(proxyLocal) do
+	for i,v in pairs(proxyLocal) do
 		if type(v) == "table" then
 			ret[i] = MakeRealTable(v)
 		else

--- a/luaui/system.lua
+++ b/luaui/system.lua
@@ -56,9 +56,9 @@ if (System == nil) then
     --  Unsynced Utilities
     --
     SYNCED  = SYNCED,
-    snext   = snext,
-    spairs  = spairs,
-    sipairs = sipairs,
+    snext   = next, -- the following 3 are deprecated, but defined in case any legacy code uses them
+    spairs  = pairs,
+    sipairs = ipairs,
 
     --
     --  Standard libraries


### PR DESCRIPTION
Obsolete, due removal in engine, and replaceable by the regular versions.